### PR TITLE
Fix README formatting and add VS Code installation steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-jogbk19/jojogbk19** is a ✨ _special_ ✨ repository because its `README.md` (this file) appears on your GitHub profile.
-
+jogbk19/jojogbk19** is a ✨ _special_ ✨ repository because its `README.md` (this file) appears on your GitHub profile
 Here are some ideas to get you started:
 
 - 🔭 I’m currently working on ...
@@ -10,12 +9,20 @@ Here are some ideas to get you started:
 - 📫 How to reach me: ... 
 - 😄 Pronouns: ...
 - ⚡ Fun fact: ...
---> "workbench.colorCustomizations": {
-    "editor.foreground": "#880000",
-    "editor.selectionBackground": "#00FF00"
-  }
-  "[javascript][typescript]": {
-  "editor.maxTokenizationLineLength": 2500
-}
+
+Install Visual Studio Code (RHEL / CentOS / Fedora — dnf)
+
 sudo rpm --import https://packages.microsoft.com/keys/microsoft.asc
-Studio Code\nbaseurl=https://packages.microsoft.com/yumrepos/vscode\nenabled=1\nautorefresh=1\ntype=rpm-md\ngpgcheck=1\ngpgkey=https://packages.
+sudo sh -c 'cat > /etc/yum.repos.d/vscode.repo <<EOF
+[code]
+name=Visual Studio Code
+baseurl=https://packages.microsoft.com/yumrepos/vscode
+enabled=1
+gpgcheck=1
+gpgkey=https://packages.microsoft.com/keys/microsoft.asc
+EOF'
+sudo dnf check-update
+sudo dnf install -y code
+
+Notes:
+- The above instructions target RHEL/CentOS/Fedora systems using dnf. If you use openSUSE (zypper) or Debian/Ubuntu (apt) let me know and I will update the instructions accordingly.


### PR DESCRIPTION
Updated README.md to correct formatting and add installation instructions for Visual Studio Code on RHEL/CentOS/Fedora.